### PR TITLE
Install Miniconda flavor that is suitable for the current CPU arch.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,9 +44,9 @@ RUN git clone --branch v3.3.0 https://github.com/soedinglab/hh-suite.git /tmp/hh
 
 # Install Miniconda package manager.
 RUN wget -q -P /tmp \
-  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
-    && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
+  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh \
+    && bash /tmp/Miniconda3-latest-Linux-$(uname -m).sh -b -p /opt/conda \
+    && rm /tmp/Miniconda3-latest-Linux-$(uname -m).sh
 
 # Install conda packages.
 ENV PATH="/opt/conda/bin:$PATH"


### PR DESCRIPTION
This is a small first step for supporting Linux ARM64.
Related-to: https://github.com/deepmind/alphafold/issues/528 and https://github.com/deepmind/alphafold/issues/530

The Docker image builds fail later with:
```
...
 Downloading jax-0.2.14.tar.gz (669 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 669.2/669.2 kB 32.0 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
ERROR: Could not find a version that satisfies the requirement jaxlib==0.1.69+cuda111 (from versions: none)
ERROR: No matching distribution found for jaxlib==0.1.69+cuda111
...
```

I tried to upgrade jax from 0.2.14 to 0.3.16 (current latest) in `requirements.txt` but it is not picked up by the Docker build. I will work on this in a separate PR because it seems it will be a bigger change.