### PR TITLE
Add conda lib path to LD_LIBRARY_PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN wget -q -P /tmp \
 
 # Install conda packages.
 ENV PATH="/opt/conda/bin:$PATH"
+ENV LD_LIBRARY_PATH="/opt/conda/lib:$LD_LIBRARY_PATH"
 RUN conda install -qy conda==4.13.0 \
     && conda install -y -c conda-forge \
       openmm=7.5.1 \


### PR DESCRIPTION
Fix the following errors which occured when running the singularity transformed docker image of alphafold 2.2.4 Dockerfile:
```
Could not load dynamic library 'libcusolver.so.11' 
```

Which generates the error:
```
RuntimeError: jaxlib/cuda/cusolver_kernels.cc:44: operation cusolverDnCreate(&handle) failed: cuSolver internal error
```

Steps to generate the Singularity image by converting the docker image:
```
$ docker build -f docker/Dockerfile -t alphafold:2.2.4 .
$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output --privileged -t --rm quay.io/singularity/docker2singularity -n alphafold_2.2.4.sif alphafold:2.2.4
$ singularity build /tmp/alphafold_2.2.4.sif docker-daemon://alphafold:2.2.4
```