### PR TITLE
Replace ftp.wwpdb.org with files.wwpdb.org

### DIFF
--- a/scripts/download_pdb_mmcif.sh
+++ b/scripts/download_pdb_mmcif.sh
@@ -62,4 +62,4 @@ done
 # Delete empty download directory structure.
 find "${RAW_DIR}" -type d -empty -delete
 
-aria2c "https://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat" --dir="${ROOT_DIR}"
+aria2c "https://files.wwpdb.org/pub/pdb/data/status/obsolete.dat" --dir="${ROOT_DIR}"

--- a/scripts/download_pdb_seqres.sh
+++ b/scripts/download_pdb_seqres.sh
@@ -31,7 +31,7 @@ fi
 
 DOWNLOAD_DIR="$1"
 ROOT_DIR="${DOWNLOAD_DIR}/pdb_seqres"
-SOURCE_URL="https://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt"
+SOURCE_URL="https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt"
 BASENAME=$(basename "${SOURCE_URL}")
 
 mkdir --parents "${ROOT_DIR}"


### PR DESCRIPTION
Last year, [wwPDB has announced](https://www.wwpdb.org/news/news?year=2022#6303be3b707ecd4f63b3d3d9) that the domain `ftp.wwpdb.org` will be replaced by `files.wwpdb.org` for the HTTPS protocol, and after Sep 2023 they are enforcing use of updated DNS names. As a side effect of [commit/4bd3ff76cc516](https://github.com/google-deepmind/alphafold/commit/4bd3ff76cc51613af617f49e8179b603ee2f1576), aria2 commands in download scripts (`scripts/download_pdb_mmcif.sh` and `scripts/download_pdb_seqres.sh`) fail now:

```
$ aria2c "https://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat" --dir=/tmp/abc
10/09 09:06:43 [NOTICE] Downloading 1 item(s)
[#7091d5 0B/0B CN:1 DL:0B]
... stuck ...

$ aria2c "https://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt" --dir=/tmp/abc2
10/09 09:11:50 [NOTICE] Downloading 1 item(s)
[#6829ee 0B/0B CN:1 DL:0B]
... stuck ...
```

We can make them work by simply replacing domain:
 ```
$ aria2c "https://files.wwpdb.org/pub/pdb/data/status/obsolete.dat" --dir=/tmp/abc
10/09 09:04:46 [NOTICE] Downloading 1 item(s)
10/09 09:04:46 [NOTICE] Download complete: /tmp/abc/obsolete.dat

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
71ae86|OK  |   0.9MiB/s|/tmp/abc/obsolete.dat

Status Legend:
(OK):download completed.


$ aria2c "https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt" --dir=/tmp/abc2
10/09 09:17:27 [NOTICE] Downloading 1 item(s)
[#ea6f55 262MiB/267MiB(98%) CN:1 DL:6.1MiB]
10/09 09:17:58 [NOTICE] Download complete: /tmp/abc2/pdb_seqres.txt

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
ea6f55|OK  |   8.4MiB/s|/tmp/abc2/pdb_seqres.txt

Status Legend:
(OK):download completed.
```

It should resolve issues  https://github.com/google-deepmind/alphafold/issues/835 and https://github.com/google-deepmind/alphafold/issues/837.

Finally, changing protocol from HTTPS to FTP to avoid download failures isn't ideal, because wwPDF states that "HTTPS protocol is preferred (over FTP) for individual file downloads" in the announcement. Instead, we should change the domain from `ftp.wwpdb.org` to `files.wwpdb.org` as proposed in this PR.