### PR TITLE
fix: update cuda image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please follow these steps:
 1.  Check that AlphaFold will be able to use a GPU by running:
 
     ```bash
-    docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
+    docker run --rm --gpus all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
     ```
 
     The output of this command should show a list of your GPUs. If it doesn't,


### PR DESCRIPTION
Fixes #805. This PR is based on [this comment](https://github.com/google-deepmind/alphafold/issues/805#issuecomment-1661283794) and is slightly more future-proof than #700 as images now have DIST appended e.g. `nvidia/cuda:11.0.3-base-${DIST}`.

Note that the DIST itself does not need to match the system, per [this comment](https://github.com/NVIDIA/nvidia-docker/issues/1735#issuecomment-1455744048).