### PR TITLE
Use `/usr/bin/env` for bash shebang

### DIFF
--- a/scripts/download_all_data.sh
+++ b/scripts/download_all_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_alphafold_params.sh
+++ b/scripts/download_alphafold_params.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_bfd.sh
+++ b/scripts/download_bfd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_mgnify.sh
+++ b/scripts/download_mgnify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_pdb70.sh
+++ b/scripts/download_pdb70.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_pdb_mmcif.sh
+++ b/scripts/download_pdb_mmcif.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_pdb_seqres.sh
+++ b/scripts/download_pdb_seqres.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_small_bfd.sh
+++ b/scripts/download_small_bfd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_uniprot.sh
+++ b/scripts/download_uniprot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_uniref30.sh
+++ b/scripts/download_uniref30.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #

--- a/scripts/download_uniref90.sh
+++ b/scripts/download_uniref90.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 DeepMind Technologies Limited
 #


### PR DESCRIPTION
Using `env` honors user preference if they override `bash` in `$PATH` or use a linux distribution that does not store `bash` at `/bin/bash` such as NixOS.

```bash
$ uname -v
$ which bash
/run/current-system/sw/bin/bash
```

References:
* https://www.oreilly.com/library/view/bash-cookbook/0596526784/ch15s01.html
* https://cloud.google.com/build/docs/configuring-builds/run-bash-scripts#using_the_script_field