### PR TITLE
Fix resolution field in mmcif_parsing

### DIFF
--- a/alphafold/data/mmcif_parsing.py
+++ b/alphafold/data/mmcif_parsing.py
@@ -315,6 +315,7 @@ def _get_header(parsed_info: MmCIFDict) -> PdbHeader:
       try:
         raw_resolution = parsed_info[res_key][0]
         header['resolution'] = float(raw_resolution)
+        break
       except ValueError:
         logging.debug('Invalid resolution format: %s', parsed_info[res_key])
 


### PR DESCRIPTION
Without the break statement this function will fall back to setting the resolution to _reflns.d_resolution_high for most structures, which reflects the resolution limit in the raw data and not the final structure (see https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_reflns.d_resolution_high.html and https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_refine.ls_d_res_high.html).

Fixes #915 