### PR TITLE
Fix deprecation warning / error from BioPython

### DIFF
--- a/alphafold/data/mmcif_parsing.py
+++ b/alphafold/data/mmcif_parsing.py
@@ -21,7 +21,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from absl import logging
 from Bio import PDB
-from Bio.Data import SCOPData
+from Bio.Data import PDBData
 
 # Type aliases:
 ChainId = str


### PR DESCRIPTION
Hi,

   Here is a small PR to fix a deprecation issue related to BioPython. It would be great if y'all could run this through CI to make sure it doesn't have any side effects, but BioPython _seems_ to promise it's a safe change.

## Description:
This PR swaps the BioPython.SCOPData module import in the mmcif_parsing module for BioPython.PDBData.

## Related issue:
See https://github.com/biopython/biopython/blob/master/DEPRECATED.rst#biodatascopdata for information about the SCOPData deprecation.

## Motivation:
SCOPData was removed in version 1.82 of BioPython, so its usage throws an error when imported. This change allows upgrading BioPython beyond version 1.79, which brings improvements in security and stability. I had been trying to use AlphaFold2 with an updated BioPython but kept receiving deprecation warnings / errors depending on which version I was using.

## Verification
  [X] Package still installs after change
  [X] `run_alphafold_test.py` returns `ok` after this change.