### PR TITLE
Remove $ROOT_DIR from the argument of gunzip command

### DIFF
--- a/scripts/download_mgnify.sh
+++ b/scripts/download_mgnify.sh
@@ -39,5 +39,5 @@ BASENAME=$(basename "${SOURCE_URL}")
 mkdir --parents "${ROOT_DIR}"
 aria2c "${SOURCE_URL}" --dir="${ROOT_DIR}"
 pushd "${ROOT_DIR}"
-gunzip "${ROOT_DIR}/${BASENAME}"
+gunzip "${BASENAME}"
 popd


### PR DESCRIPTION
The script fails with the following error because `${ROOT_DIR}` exists when the gunzip command is executed.

```
gzip: download_dir/mgnify/mgy_clusters_2022_05.fa.gz: No such file or directory
```