### PR TITLE
Add rsync notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Please follow these steps:
     package manager as the `aria2` package (on Debian-based distributions this
     can be installed by running `sudo apt install aria2`).
 
+    *   Make sure `rsync` is available. On most Linux distributions it should already be installed.
+    If not, it should be available via the package manager as the `rsync` package
+    (on Debian-based distributions this can bi installed by running `sudo apt install rsync`).
+
     *   Please use the script `scripts/download_all_data.sh` to download
     and set up full databases. This may take substantial time (download size is
     556 GB), so we recommend running this script in the background:

--- a/scripts/download_all_data.sh
+++ b/scripts/download_all_data.sh
@@ -29,6 +29,11 @@ if ! command -v aria2c &> /dev/null ; then
   exit 1
 fi
 
+if ! command -v rsync &> /dev/null ; then
+    echo "Error: rsync could not be found. Please install rsync."
+    exit 1
+fi
+
 DOWNLOAD_DIR="$1"
 DOWNLOAD_MODE="${2:-full_dbs}"  # Default mode to full_dbs.
 if [[ "${DOWNLOAD_MODE}" != full_dbs && "${DOWNLOAD_MODE}" != reduced_dbs ]]


### PR DESCRIPTION
The PR adds a notice to the README at the section about download the DB and also a check in the download_all_data.sh, so it won't even start, if rsync isn't available.