### PR TITLE
Fix CUDA's Docker image version in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please follow these steps:
 1.  Check that AlphaFold will be able to use a GPU by running:
 
     ```bash
-    docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
+    docker run --rm --gpus all nvidia/cuda:11.0.3-base nvidia-smi
     ```
 
     The output of this command should show a list of your GPUs. If it doesn't,


### PR DESCRIPTION
nvidia/cuda:11.0-base Docker image doesn't exist.