### PR TITLE
feat: Implementing parallelization for unzipping files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please follow these steps:
     *   Install `aria2c`. On most Linux distributions it is available via the
         package manager as the `aria2` package (on Debian-based distributions
         this can be installed by running `sudo apt install aria2`).
-        Same for `rsync`.
+        Same for `rsync` and `parallel` (`sudo apt install rsync parallel`).
 
     *   Please use the script `scripts/download_all_data.sh` to download and set
         up full databases. This may take substantial time (download size is 556
@@ -150,7 +150,7 @@ Please follow these steps:
 
 ### Genetic databases
 
-This step requires `aria2c` to be installed on your machine.
+This step requires `aria2c` and `rsync` to be installed on your machine. `GNU Parallel` is also highly recommended to speed up the unzipping process.
 
 AlphaFold needs multiple genetic (sequence) databases to run:
 
@@ -731,6 +731,7 @@ and packages:
 *   [Docker](https://www.docker.com)
 *   [HH Suite](https://github.com/soedinglab/hh-suite)
 *   [HMMER Suite](http://eddylab.org/software/hmmer)
+*   [GNU Parallel](https://www.gnu.org/software/parallel/)
 *   [Haiku](https://github.com/deepmind/dm-haiku)
 *   [JAX](https://github.com/google/jax/)
 *   [Kalign](https://msa.sbc.su.se/cgi-bin/msa.cgi)

--- a/scripts/download_pdb_mmcif.sh
+++ b/scripts/download_pdb_mmcif.sh
@@ -52,7 +52,7 @@ rsync --recursive --links --perms --times --compress --info=progress2 --delete -
 echo "Unzipping all mmCIF files..."
 if command -v parallel >/dev/null 2>&1
 then
-   find "${RAW_DIR}/" -type f -iname "*.gz" -print0 | parallel -0 -j -1 gunzip
+   find "${RAW_DIR}/" -type f -iname "*.gz" -print0 | parallel -0 -j -1 --xargs gunzip
 else
    find "${RAW_DIR}/" -type f -iname "*.gz" -exec gunzip {} +
 fi

--- a/scripts/download_pdb_mmcif.sh
+++ b/scripts/download_pdb_mmcif.sh
@@ -50,7 +50,12 @@ rsync --recursive --links --perms --times --compress --info=progress2 --delete -
   "${RAW_DIR}"
 
 echo "Unzipping all mmCIF files..."
-find "${RAW_DIR}/" -type f -iname "*.gz" -exec gunzip {} +
+if command -v parallel >/dev/null 2>&1
+then
+   find "${RAW_DIR}/" -type f -iname "*.gz" -print0 | parallel -0 -j -1 gunzip
+else
+   find "${RAW_DIR}/" -type f -iname "*.gz" -exec gunzip {} +
+fi
 
 echo "Flattening all mmCIF files..."
 mkdir --parents "${MMCIF_DIR}"


### PR DESCRIPTION
### Description
This PR implements GNU Parallel-based unzipping for 200,000+ *.cif.gz files in the AlphaFold pipeline.

### The Problem:
The current unzipping process is strictly serial, which is extremely slow for large datasets. This limits efficiency and delays downstream processing.

### The Fix:

Added a check for GNU Parallel availability.

Automatically detects the number of CPU cores, leaving one core free for I/O-bound tasks and using the remaining cores for parallel unzipping.

Falls back to the existing serial method if GNU Parallel is not installed.

Updated README.md to reflect the new parallelization option and usage instructions.

Fixes: #1075